### PR TITLE
Update Dockerfile.deployer

### DIFF
--- a/ops/docker/Dockerfile.deployer
+++ b/ops/docker/Dockerfile.deployer
@@ -4,7 +4,7 @@ FROM ${LOCAL_REGISTRY}/ethereumoptimism/builder:${BUILDER_TAG} AS builder
 
 FROM node:14-alpine
 
-RUN apk add --update --no-cache git curl python bash jq
+RUN apk add --update --no-cache git curl python3 bash jq
 
 WORKDIR /opt/optimism/
 


### PR DESCRIPTION
Mysteriously, have to use python3 in place of python, otherwise there will be a Python package not found error.
Maybe docker Linux removed link to python to avoid conflict between python 3.x and legacy python2.